### PR TITLE
Fix/1 0 1

### DIFF
--- a/CockpitPlugin/build.gradle
+++ b/CockpitPlugin/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 group = 'com.polidea.cockpit'
-version = '1.0.1-SNAPSHOT'
+version = '1.0.1'
 
 sourceCompatibility = 1.7
 

--- a/CockpitPlugin/build.gradle
+++ b/CockpitPlugin/build.gradle
@@ -19,7 +19,7 @@ plugins {
 }
 
 group = 'com.polidea.cockpit'
-version = '1.0.0'
+version = '1.0.1-SNAPSHOT'
 
 sourceCompatibility = 1.7
 

--- a/CockpitPlugin/src/main/java/com/polidea/cockpitplugin/generator/BaseCockpitGenerator.kt
+++ b/CockpitPlugin/src/main/java/com/polidea/cockpitplugin/generator/BaseCockpitGenerator.kt
@@ -44,7 +44,7 @@ abstract class BaseCockpitGenerator {
 
     inline protected fun createGetterMethodSpecForParamAndConfigurator(param: Param<*>,
                                                                      configurator: (MethodSpec.Builder) -> MethodSpec.Builder): MethodSpec {
-        return configurator(MethodSpec.methodBuilder("get${param.name}")
+        return configurator(MethodSpec.methodBuilder("get${param.name.capitalize()}")
                 .returns(mapToTypeClass(param))
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC))
                 .build()

--- a/CockpitPlugin/src/main/java/com/polidea/cockpitplugin/generator/BaseCockpitGenerator.kt
+++ b/CockpitPlugin/src/main/java/com/polidea/cockpitplugin/generator/BaseCockpitGenerator.kt
@@ -13,6 +13,7 @@ abstract class BaseCockpitGenerator {
     protected val cockpitManagerPackage = "com.polidea.cockpit.manager"
     protected val androidContentPackage = "android.content"
     protected val cockpitActivityPackage = "com.polidea.cockpit.activity"
+    protected val cockpitUtilsPackage = "com.polidea.cockpit.utils"
 
     protected val cockpit = "Cockpit"
     protected val cockpitManager = "CockpitManager"
@@ -20,12 +21,14 @@ abstract class BaseCockpitGenerator {
     protected val intent = "Intent"
     protected val context = "Context"
     protected val cockpitActivity = "CockpitActivity"
+    protected val fileUtils = "FileUtils"
 
     protected val cockpitManagerClassName = ClassName.get(cockpitManagerPackage, cockpitManager)
     protected val cockpitParamClassName = ClassName.get(cockpitManagerPackage, cockpitParam)
     protected val androidIntentClassName = ClassName.get(androidContentPackage, intent)
     protected val androidContextClassName = ClassName.get(androidContentPackage, context)
     protected val cockpitActivityClassName = ClassName.get(cockpitActivityPackage, cockpitActivity)
+    protected val fileUtilsClassName = ClassName.get(cockpitUtilsPackage, fileUtils)
 
     protected fun generate(file: File?, configurator: (TypeSpec.Builder) -> TypeSpec.Builder) {
 

--- a/CockpitPlugin/src/main/java/com/polidea/cockpitplugin/generator/DebugCockpitGenerator.kt
+++ b/CockpitPlugin/src/main/java/com/polidea/cockpitplugin/generator/DebugCockpitGenerator.kt
@@ -19,6 +19,7 @@ class DebugCockpitGenerator : BaseCockpitGenerator() {
                     .addMethod(createInitCockpitMethod(params))
                     .addMethods(propertyMethods)
                     .addMethod(generateShowCockpitMethod())
+                    .addMethod(generatePersistChangesMethod())
         }
     }
 
@@ -37,6 +38,7 @@ class DebugCockpitGenerator : BaseCockpitGenerator() {
                 .addParameter(ParameterSpec.builder(typeClass, param.name).build())
                 .addStatement("\$T.getInstance().setParamValue(\"${param.name}\", ${param.name})",
                         cockpitManagerClassName)
+                .addStatement("persistChanges()")
                 .build()
     }
 
@@ -58,6 +60,13 @@ class DebugCockpitGenerator : BaseCockpitGenerator() {
                 .addStatement("\$T intent = new \$T(context, \$T.class)",
                         androidIntentClassName, androidIntentClassName, cockpitActivityClassName)
                 .addStatement("context.startActivity(intent)")
+                .build()
+    }
+
+    internal fun generatePersistChangesMethod(): MethodSpec {
+        return MethodSpec.methodBuilder("persistChanges")
+                .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
+                .addStatement("\$T.getInstance().saveCockpitAsYaml()", fileUtilsClassName)
                 .build()
     }
 }

--- a/CockpitPlugin/src/main/java/com/polidea/cockpitplugin/generator/DebugCockpitGenerator.kt
+++ b/CockpitPlugin/src/main/java/com/polidea/cockpitplugin/generator/DebugCockpitGenerator.kt
@@ -25,7 +25,7 @@ class DebugCockpitGenerator : BaseCockpitGenerator() {
 
     internal fun createGetterMethodSpecForParam(param: Param<*>): MethodSpec {
         return createGetterMethodSpecForParamAndConfigurator(param) { builder ->
-            builder.addStatement("return (\$T) \$T.getInstance().getParamValue(\"${param.name}\")",
+            builder.addStatement("return (\$T) \$T.INSTANCE.getParamValue(\"${param.name}\")",
                     mapToTypeClass(param), cockpitManagerClassName)
         }
     }
@@ -36,7 +36,7 @@ class DebugCockpitGenerator : BaseCockpitGenerator() {
         return MethodSpec.methodBuilder("set${param.name.capitalize()}")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addParameter(ParameterSpec.builder(typeClass, param.name).build())
-                .addStatement("\$T.getInstance().setParamValue(\"${param.name}\", ${param.name})",
+                .addStatement("\$T.INSTANCE.setParamValue(\"${param.name}\", ${param.name})",
                         cockpitManagerClassName)
                 .addStatement("persistChanges()")
                 .build()
@@ -47,7 +47,7 @@ class DebugCockpitGenerator : BaseCockpitGenerator() {
                 .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
 
         params.forEach {
-            funSpec.addStatement("$cockpitManager.getInstance().addParam(new \$T(\"${it.name}\", ${it.value.javaClass.simpleName}.class, ${createWrappedValueForParam(it)}))", cockpitParamClassName)
+            funSpec.addStatement("$cockpitManager.INSTANCE.addParam(new \$T(\"${it.name}\", ${it.value.javaClass.simpleName}.class, ${createWrappedValueForParam(it)}))", cockpitParamClassName)
         }
 
         return funSpec.build()
@@ -66,7 +66,7 @@ class DebugCockpitGenerator : BaseCockpitGenerator() {
     internal fun generatePersistChangesMethod(): MethodSpec {
         return MethodSpec.methodBuilder("persistChanges")
                 .addModifiers(Modifier.PRIVATE, Modifier.STATIC)
-                .addStatement("\$T.getInstance().saveCockpitAsYaml()", fileUtilsClassName)
+                .addStatement("\$T.INSTANCE.saveCockpitAsYaml()", fileUtilsClassName)
                 .build()
     }
 }

--- a/CockpitPlugin/src/main/java/com/polidea/cockpitplugin/generator/DebugCockpitGenerator.kt
+++ b/CockpitPlugin/src/main/java/com/polidea/cockpitplugin/generator/DebugCockpitGenerator.kt
@@ -19,7 +19,6 @@ class DebugCockpitGenerator : BaseCockpitGenerator() {
                     .addMethod(createInitCockpitMethod(params))
                     .addMethods(propertyMethods)
                     .addMethod(generateShowCockpitMethod())
-                    .addMethod(generateHideCockpitMethod())
         }
     }
 
@@ -59,15 +58,6 @@ class DebugCockpitGenerator : BaseCockpitGenerator() {
                 .addStatement("\$T intent = new \$T(context, \$T.class)",
                         androidIntentClassName, androidIntentClassName, cockpitActivityClassName)
                 .addStatement("context.startActivity(intent)")
-                .build()
-    }
-
-
-    internal fun generateHideCockpitMethod(): MethodSpec {
-        return MethodSpec.methodBuilder("hideCockpit")
-                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                .addParameter(ParameterSpec.builder(cockpitActivityClassName, "cockpitActivity").build())
-                .addStatement("cockpitActivity.finish()")
                 .build()
     }
 }

--- a/CockpitPlugin/src/main/java/com/polidea/cockpitplugin/generator/DebugCockpitGenerator.kt
+++ b/CockpitPlugin/src/main/java/com/polidea/cockpitplugin/generator/DebugCockpitGenerator.kt
@@ -33,7 +33,7 @@ class DebugCockpitGenerator : BaseCockpitGenerator() {
 
     internal fun createSetterMethodSpecForParam(param: Param<*>): MethodSpec {
         val typeClass = mapToTypeClass(param)
-        return MethodSpec.methodBuilder("set${param.name}")
+        return MethodSpec.methodBuilder("set${param.name.capitalize()}")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addParameter(ParameterSpec.builder(typeClass, param.name).build())
                 .addStatement("\$T.getInstance().setParamValue(\"${param.name}\", ${param.name})",

--- a/CockpitPlugin/src/test/java/com/polidea/cockpitplugin/generator/DebugCockpitGeneratorTest.kt
+++ b/CockpitPlugin/src/test/java/com/polidea/cockpitplugin/generator/DebugCockpitGeneratorTest.kt
@@ -15,7 +15,7 @@ class DebugCockpitGeneratorTest {
 
         val expectedDoubleGetterMethodSpecString = """
             |public static double getDoubleParam() {
-            |  return (double) com.polidea.cockpit.manager.CockpitManager.getInstance().getParamValue("doubleParam");
+            |  return (double) com.polidea.cockpit.manager.CockpitManager.INSTANCE.getParamValue("doubleParam");
             |}"""
         assertEquals(expectedDoubleGetterMethodSpecString.trimMargin(), doubleGetterMethodSpec.toString().trimMargin())
     }
@@ -26,7 +26,7 @@ class DebugCockpitGeneratorTest {
 
         val expectedDoubleSetterMethodSpecString = """
             |public static void setDoubleParam(double doubleParam) {
-            |  com.polidea.cockpit.manager.CockpitManager.getInstance().setParamValue("doubleParam", doubleParam);
+            |  com.polidea.cockpit.manager.CockpitManager.INSTANCE.setParamValue("doubleParam", doubleParam);
             |  persistChanges();
             |}"""
         assertEquals(expectedDoubleSetterMethodSpecString.trimMargin(), doubleSetterMethodSpec.toString().trimMargin())
@@ -38,7 +38,7 @@ class DebugCockpitGeneratorTest {
 
         val expectedIntegerGetterMethodSpecString = """
             |public static int getIntegerParam() {
-            |  return (int) com.polidea.cockpit.manager.CockpitManager.getInstance().getParamValue("integerParam");
+            |  return (int) com.polidea.cockpit.manager.CockpitManager.INSTANCE.getParamValue("integerParam");
             |}"""
         assertEquals(expectedIntegerGetterMethodSpecString.trimMargin(), intGetterMethodSpec.toString().trimMargin())
     }
@@ -49,7 +49,7 @@ class DebugCockpitGeneratorTest {
 
         val expectedDoubleSetterMethodSpecString = """
             |public static void setIntegerParam(int integerParam) {
-            |  com.polidea.cockpit.manager.CockpitManager.getInstance().setParamValue("integerParam", integerParam);
+            |  com.polidea.cockpit.manager.CockpitManager.INSTANCE.setParamValue("integerParam", integerParam);
             |  persistChanges();
             |}"""
         assertEquals(expectedDoubleSetterMethodSpecString.trimMargin(), intSetterMethodSpec.toString().trimMargin())
@@ -61,7 +61,7 @@ class DebugCockpitGeneratorTest {
 
         val expectedBooleanGetterMethodSpecString = """
             |public static boolean getBooleanParam() {
-            |  return (boolean) com.polidea.cockpit.manager.CockpitManager.getInstance().getParamValue("booleanParam");
+            |  return (boolean) com.polidea.cockpit.manager.CockpitManager.INSTANCE.getParamValue("booleanParam");
             |}"""
         assertEquals(expectedBooleanGetterMethodSpecString.trimMargin(), booleanGetterMethodSpec.toString().trimMargin())
     }
@@ -72,7 +72,7 @@ class DebugCockpitGeneratorTest {
 
         val expectedBooleanSetterMethodSpecString = """
             |public static void setBooleanParam(boolean booleanParam) {
-            |  com.polidea.cockpit.manager.CockpitManager.getInstance().setParamValue("booleanParam", booleanParam);
+            |  com.polidea.cockpit.manager.CockpitManager.INSTANCE.setParamValue("booleanParam", booleanParam);
             |  persistChanges();
             |}"""
         assertEquals(expectedBooleanSetterMethodSpecString.trimMargin(), booleanSetterMethodSpec.toString().trimMargin())
@@ -84,7 +84,7 @@ class DebugCockpitGeneratorTest {
 
         val expectedStringGetterMethodSpecString = """
             |public static java.lang.String getStringParam() {
-            |  return (java.lang.String) com.polidea.cockpit.manager.CockpitManager.getInstance().getParamValue("stringParam");
+            |  return (java.lang.String) com.polidea.cockpit.manager.CockpitManager.INSTANCE.getParamValue("stringParam");
             |}"""
         assertEquals(expectedStringGetterMethodSpecString.trimMargin(), stringGetterMethodSpec.toString().trimMargin())
     }
@@ -95,7 +95,7 @@ class DebugCockpitGeneratorTest {
 
         val expectedStringSetterMethodSpecString = """
             |public static void setStringParam(java.lang.String stringParam) {
-            |  com.polidea.cockpit.manager.CockpitManager.getInstance().setParamValue("stringParam", stringParam);
+            |  com.polidea.cockpit.manager.CockpitManager.INSTANCE.setParamValue("stringParam", stringParam);
             |  persistChanges();
             |}"""
         assertEquals(expectedStringSetterMethodSpecString.trimMargin(), stringSetterMethodSpec.toString().trimMargin())
@@ -110,10 +110,10 @@ class DebugCockpitGeneratorTest {
 
         val expectedFunSpecString = """
             |private static void initializeCockpit() {
-            |  CockpitManager.getInstance().addParam(new com.polidea.cockpit.manager.CockpitParam("doubleParam", Double.class, 3.0));
-            |  CockpitManager.getInstance().addParam(new com.polidea.cockpit.manager.CockpitParam("booleanParam", Boolean.class, false));
-            |  CockpitManager.getInstance().addParam(new com.polidea.cockpit.manager.CockpitParam("stringParam", String.class, "testValue"));
-            |  CockpitManager.getInstance().addParam(new com.polidea.cockpit.manager.CockpitParam("integerParam", Integer.class, 2));
+            |  CockpitManager.INSTANCE.addParam(new com.polidea.cockpit.manager.CockpitParam("doubleParam", Double.class, 3.0));
+            |  CockpitManager.INSTANCE.addParam(new com.polidea.cockpit.manager.CockpitParam("booleanParam", Boolean.class, false));
+            |  CockpitManager.INSTANCE.addParam(new com.polidea.cockpit.manager.CockpitParam("stringParam", String.class, "testValue"));
+            |  CockpitManager.INSTANCE.addParam(new com.polidea.cockpit.manager.CockpitParam("integerParam", Integer.class, 2));
             |}"""
 
         assertEquals(expectedFunSpecString.trimMargin(), funSpec.toString().trimMargin())
@@ -138,7 +138,7 @@ class DebugCockpitGeneratorTest {
 
         val expectedFunSpecString = """
             |private static void persistChanges() {
-            |  com.polidea.cockpit.utils.FileUtils.getInstance().saveCockpitAsYaml();
+            |  com.polidea.cockpit.utils.FileUtils.INSTANCE.saveCockpitAsYaml();
             |}"""
 
         assertEquals(expectedFunSpecString.trimMargin(), funSpec.toString().trimMargin())

--- a/CockpitPlugin/src/test/java/com/polidea/cockpitplugin/generator/DebugCockpitGeneratorTest.kt
+++ b/CockpitPlugin/src/test/java/com/polidea/cockpitplugin/generator/DebugCockpitGeneratorTest.kt
@@ -27,6 +27,7 @@ class DebugCockpitGeneratorTest {
         val expectedDoubleSetterMethodSpecString = """
             |public static void setDoubleParam(double doubleParam) {
             |  com.polidea.cockpit.manager.CockpitManager.getInstance().setParamValue("doubleParam", doubleParam);
+            |  persistChanges();
             |}"""
         assertEquals(expectedDoubleSetterMethodSpecString.trimMargin(), doubleSetterMethodSpec.toString().trimMargin())
     }
@@ -49,6 +50,7 @@ class DebugCockpitGeneratorTest {
         val expectedDoubleSetterMethodSpecString = """
             |public static void setIntegerParam(int integerParam) {
             |  com.polidea.cockpit.manager.CockpitManager.getInstance().setParamValue("integerParam", integerParam);
+            |  persistChanges();
             |}"""
         assertEquals(expectedDoubleSetterMethodSpecString.trimMargin(), intSetterMethodSpec.toString().trimMargin())
     }
@@ -71,6 +73,7 @@ class DebugCockpitGeneratorTest {
         val expectedBooleanSetterMethodSpecString = """
             |public static void setBooleanParam(boolean booleanParam) {
             |  com.polidea.cockpit.manager.CockpitManager.getInstance().setParamValue("booleanParam", booleanParam);
+            |  persistChanges();
             |}"""
         assertEquals(expectedBooleanSetterMethodSpecString.trimMargin(), booleanSetterMethodSpec.toString().trimMargin())
     }
@@ -93,6 +96,7 @@ class DebugCockpitGeneratorTest {
         val expectedStringSetterMethodSpecString = """
             |public static void setStringParam(java.lang.String stringParam) {
             |  com.polidea.cockpit.manager.CockpitManager.getInstance().setParamValue("stringParam", stringParam);
+            |  persistChanges();
             |}"""
         assertEquals(expectedStringSetterMethodSpecString.trimMargin(), stringSetterMethodSpec.toString().trimMargin())
     }
@@ -125,8 +129,18 @@ class DebugCockpitGeneratorTest {
             |  context.startActivity(intent);
             |}"""
 
-        System.out.println("expected: " + expectedFunSpecString.trimMargin())
-        System.out.println("given   : " + funSpec.toString().trimMargin())
+        assertEquals(expectedFunSpecString.trimMargin(), funSpec.toString().trimMargin())
+    }
+
+    @Test
+    fun generatePersistChangesMethodTest() {
+        val funSpec = cockpitGenerator.generatePersistChangesMethod()
+
+        val expectedFunSpecString = """
+            |private static void persistChanges() {
+            |  com.polidea.cockpit.utils.FileUtils.getInstance().saveCockpitAsYaml();
+            |}"""
+
         assertEquals(expectedFunSpecString.trimMargin(), funSpec.toString().trimMargin())
     }
 

--- a/CockpitPlugin/src/test/java/com/polidea/cockpitplugin/generator/DebugCockpitGeneratorTest.kt
+++ b/CockpitPlugin/src/test/java/com/polidea/cockpitplugin/generator/DebugCockpitGeneratorTest.kt
@@ -130,18 +130,6 @@ class DebugCockpitGeneratorTest {
         assertEquals(expectedFunSpecString.trimMargin(), funSpec.toString().trimMargin())
     }
 
-    @Test
-    fun generateHideCockpitMethodTest() {
-        val funSpec = cockpitGenerator.generateHideCockpitMethod()
-
-        val expectedFunSpecString = """
-            |public static void hideCockpit(com.polidea.cockpit.activity.CockpitActivity cockpitActivity) {
-            |  cockpitActivity.finish();
-            |}"""
-
-        assertEquals(expectedFunSpecString.trimMargin(), funSpec.toString().trimMargin())
-    }
-
     private fun getTestParams(): List<Param<*>> {
         val testParams: MutableList<Param<*>> = mutableListOf()
 

--- a/CockpitPlugin/src/test/java/com/polidea/cockpitplugin/generator/DebugCockpitGeneratorTest.kt
+++ b/CockpitPlugin/src/test/java/com/polidea/cockpitplugin/generator/DebugCockpitGeneratorTest.kt
@@ -14,7 +14,7 @@ class DebugCockpitGeneratorTest {
         val doubleGetterMethodSpec = cockpitGenerator.createGetterMethodSpecForParam(DoubleParam("doubleParam", 3.0))
 
         val expectedDoubleGetterMethodSpecString = """
-            |public static double getdoubleParam() {
+            |public static double getDoubleParam() {
             |  return (double) com.polidea.cockpit.manager.CockpitManager.getInstance().getParamValue("doubleParam");
             |}"""
         assertEquals(expectedDoubleGetterMethodSpecString.trimMargin(), doubleGetterMethodSpec.toString().trimMargin())
@@ -25,7 +25,7 @@ class DebugCockpitGeneratorTest {
         val doubleSetterMethodSpec = cockpitGenerator.createSetterMethodSpecForParam(DoubleParam("doubleParam", 3.0))
 
         val expectedDoubleSetterMethodSpecString = """
-            |public static void setdoubleParam(double doubleParam) {
+            |public static void setDoubleParam(double doubleParam) {
             |  com.polidea.cockpit.manager.CockpitManager.getInstance().setParamValue("doubleParam", doubleParam);
             |}"""
         assertEquals(expectedDoubleSetterMethodSpecString.trimMargin(), doubleSetterMethodSpec.toString().trimMargin())
@@ -36,7 +36,7 @@ class DebugCockpitGeneratorTest {
         val intGetterMethodSpec = cockpitGenerator.createGetterMethodSpecForParam(IntegerParam("integerParam", 2))
 
         val expectedIntegerGetterMethodSpecString = """
-            |public static int getintegerParam() {
+            |public static int getIntegerParam() {
             |  return (int) com.polidea.cockpit.manager.CockpitManager.getInstance().getParamValue("integerParam");
             |}"""
         assertEquals(expectedIntegerGetterMethodSpecString.trimMargin(), intGetterMethodSpec.toString().trimMargin())
@@ -47,7 +47,7 @@ class DebugCockpitGeneratorTest {
         val intSetterMethodSpec = cockpitGenerator.createSetterMethodSpecForParam(IntegerParam("integerParam", 2))
 
         val expectedDoubleSetterMethodSpecString = """
-            |public static void setintegerParam(int integerParam) {
+            |public static void setIntegerParam(int integerParam) {
             |  com.polidea.cockpit.manager.CockpitManager.getInstance().setParamValue("integerParam", integerParam);
             |}"""
         assertEquals(expectedDoubleSetterMethodSpecString.trimMargin(), intSetterMethodSpec.toString().trimMargin())
@@ -58,7 +58,7 @@ class DebugCockpitGeneratorTest {
         val booleanGetterMethodSpec = cockpitGenerator.createGetterMethodSpecForParam(BooleanParam("booleanParam", false))
 
         val expectedBooleanGetterMethodSpecString = """
-            |public static boolean getbooleanParam() {
+            |public static boolean getBooleanParam() {
             |  return (boolean) com.polidea.cockpit.manager.CockpitManager.getInstance().getParamValue("booleanParam");
             |}"""
         assertEquals(expectedBooleanGetterMethodSpecString.trimMargin(), booleanGetterMethodSpec.toString().trimMargin())
@@ -69,7 +69,7 @@ class DebugCockpitGeneratorTest {
         val booleanSetterMethodSpec = cockpitGenerator.createSetterMethodSpecForParam(BooleanParam("booleanParam", false))
 
         val expectedBooleanSetterMethodSpecString = """
-            |public static void setbooleanParam(boolean booleanParam) {
+            |public static void setBooleanParam(boolean booleanParam) {
             |  com.polidea.cockpit.manager.CockpitManager.getInstance().setParamValue("booleanParam", booleanParam);
             |}"""
         assertEquals(expectedBooleanSetterMethodSpecString.trimMargin(), booleanSetterMethodSpec.toString().trimMargin())
@@ -80,7 +80,7 @@ class DebugCockpitGeneratorTest {
         val stringGetterMethodSpec = cockpitGenerator.createGetterMethodSpecForParam(StringParam("stringParam", "testValue"))
 
         val expectedStringGetterMethodSpecString = """
-            |public static java.lang.String getstringParam() {
+            |public static java.lang.String getStringParam() {
             |  return (java.lang.String) com.polidea.cockpit.manager.CockpitManager.getInstance().getParamValue("stringParam");
             |}"""
         assertEquals(expectedStringGetterMethodSpecString.trimMargin(), stringGetterMethodSpec.toString().trimMargin())
@@ -91,7 +91,7 @@ class DebugCockpitGeneratorTest {
         val stringSetterMethodSpec = cockpitGenerator.createSetterMethodSpecForParam(StringParam("stringParam", "testValue"))
 
         val expectedStringSetterMethodSpecString = """
-            |public static void setstringParam(java.lang.String stringParam) {
+            |public static void setStringParam(java.lang.String stringParam) {
             |  com.polidea.cockpit.manager.CockpitManager.getInstance().setParamValue("stringParam", stringParam);
             |}"""
         assertEquals(expectedStringSetterMethodSpecString.trimMargin(), stringSetterMethodSpec.toString().trimMargin())

--- a/CockpitPlugin/src/test/java/com/polidea/cockpitplugin/generator/ReleaseCockpitGeneratorTest.kt
+++ b/CockpitPlugin/src/test/java/com/polidea/cockpitplugin/generator/ReleaseCockpitGeneratorTest.kt
@@ -13,7 +13,7 @@ class ReleaseCockpitGeneratorTest {
         val doubleGetterMethodSpec = cockpitGenerator.createGetterMethodSpecForParam(DoubleParam("doubleParam", 3.0))
 
         val expectedDoubleGetterMethodSpecString = """
-            |public static double getdoubleParam() {
+            |public static double getDoubleParam() {
             |  return 3.0;
             |}"""
         assertEquals(expectedDoubleGetterMethodSpecString.trimMargin(), doubleGetterMethodSpec.toString().trimMargin())
@@ -24,7 +24,7 @@ class ReleaseCockpitGeneratorTest {
         val intGetterMethodSpec = cockpitGenerator.createGetterMethodSpecForParam(IntegerParam("integerParam", 2))
 
         val expectedIntegerGetterMethodSpecString = """
-            |public static int getintegerParam() {
+            |public static int getIntegerParam() {
             |  return 2;
             |}"""
         assertEquals(expectedIntegerGetterMethodSpecString.trimMargin(), intGetterMethodSpec.toString().trimMargin())
@@ -35,7 +35,7 @@ class ReleaseCockpitGeneratorTest {
         val booleanGetterMethodSpec = cockpitGenerator.createGetterMethodSpecForParam(BooleanParam("booleanParam", false))
 
         val expectedBooleanGetterMethodSpecString = """
-            |public static boolean getbooleanParam() {
+            |public static boolean getBooleanParam() {
             |  return false;
             |}"""
         assertEquals(expectedBooleanGetterMethodSpecString.trimMargin(), booleanGetterMethodSpec.toString().trimMargin())
@@ -46,7 +46,7 @@ class ReleaseCockpitGeneratorTest {
         val stringGetterMethodSpec = cockpitGenerator.createGetterMethodSpecForParam(StringParam("stringParam", "testValue"))
 
         val expectedStringGetterMethodSpecString = """
-            |public static java.lang.String getstringParam() {
+            |public static java.lang.String getStringParam() {
             |  return "testValue";
             |}"""
         assertEquals(expectedStringGetterMethodSpecString.trimMargin(), stringGetterMethodSpec.toString().trimMargin())

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ buildscript {
         }
     }  
     dependencies {  
-        classpath "gradle.plugin.com.polidea.cockpit:CockpitPlugin:1.0.0"  
+        classpath "gradle.plugin.com.polidea.cockpit:CockpitPlugin:1.0.1"  
    }  
 }
 
 dependencies {
-    debugImplementation 'com.polidea.cockpit:cockpit:1.0.0'  
+    debugImplementation 'com.polidea.cockpit:cockpit:1.0.1'  
 }
 ```
 ## License

--- a/cockpit/build.gradle
+++ b/cockpit/build.gradle
@@ -48,5 +48,5 @@ dependencies {
 
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
-    testImplementation "io.mockk:mockk:1.7.9"
+    testImplementation "io.mockk:mockk:1.7.15"
 }

--- a/cockpit/src/main/java/com/polidea/cockpit/activity/CockpitActivity.kt
+++ b/cockpit/src/main/java/com/polidea/cockpit/activity/CockpitActivity.kt
@@ -16,7 +16,7 @@ class CockpitActivity : AppCompatActivity() {
 
     val TAG = CockpitActivity::class.java.simpleName
 
-    var params = CockpitManager.getInstance().params
+    var params = CockpitManager.params
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -31,14 +31,14 @@ class CockpitActivity : AppCompatActivity() {
     }
 
     private fun saveCockpit() {
-        val cockpitViews: ArrayList<ParamView<*>> = ViewUtils().getFlatChildren(cockpit_view)
+        val cockpitViews: ArrayList<ParamView<*>> = ViewUtils.getFlatChildren(cockpit_view)
 
         cockpitViews.forEach { view ->
             params.find {
                 it.name == view.paramName
             }?.also {
                         try {
-                            CockpitManager.getInstance().setParamValue(it.name, view.getCurrentValue())
+                            CockpitManager.setParamValue(it.name, view.getCurrentValue())
                         } catch (e: CockpitFormatException) {
                             Toast.makeText(this, "Invalid param value for: ${view.paramName}", Toast.LENGTH_SHORT).show()
                             Log.w(TAG, "Invalid param value for: ${view.paramName}")
@@ -47,7 +47,7 @@ class CockpitActivity : AppCompatActivity() {
                     }
         }
 
-        FileUtils.getInstance().saveCockpitAsYaml()
+        FileUtils.saveCockpitAsYaml()
 
         finish()
     }

--- a/cockpit/src/main/java/com/polidea/cockpit/activity/CockpitActivity.kt
+++ b/cockpit/src/main/java/com/polidea/cockpit/activity/CockpitActivity.kt
@@ -47,7 +47,7 @@ class CockpitActivity : AppCompatActivity() {
                     }
         }
 
-        FileUtils(this).saveCockpitAsYaml()
+        FileUtils.getInstance().saveCockpitAsYaml()
 
         finish()
     }

--- a/cockpit/src/main/java/com/polidea/cockpit/manager/CockpitManager.kt
+++ b/cockpit/src/main/java/com/polidea/cockpit/manager/CockpitManager.kt
@@ -1,22 +1,8 @@
 package com.polidea.cockpit.manager
 
-class CockpitManager private constructor() {
+object CockpitManager {
 
-    var params: MutableList<CockpitParam> = ArrayList()
-
-    companion object {
-        @Volatile
-        private var INSTANCE: CockpitManager? = null
-
-        @JvmStatic
-        fun getInstance(): CockpitManager {
-            if (INSTANCE == null) {
-                INSTANCE = CockpitManager()
-            }
-
-            return INSTANCE as CockpitManager
-        }
-    }
+    val params: MutableList<CockpitParam> = ArrayList()
 
     fun addParam(param: CockpitParam) {
         checkIfExistsAndAddParam(param)
@@ -41,6 +27,10 @@ class CockpitManager private constructor() {
 
     fun exists(key: String): Boolean {
         return params.find { it.name == key } != null
+    }
+
+    fun clear() {
+        params.clear()
     }
 
     private fun getParam(name: String): CockpitParam? = params.find { it.name == name }

--- a/cockpit/src/main/java/com/polidea/cockpit/utils/CockpitInitProvider.kt
+++ b/cockpit/src/main/java/com/polidea/cockpit/utils/CockpitInitProvider.kt
@@ -8,7 +8,8 @@ import android.net.Uri
 class CockpitInitProvider : ContentProvider() {
 
     override fun onCreate(): Boolean {
-        FileUtils(context).readCockpitFromFile()
+        FileUtils.init(context)
+        FileUtils.getInstance().readCockpitFromFile()
         return false
     }
 

--- a/cockpit/src/main/java/com/polidea/cockpit/utils/CockpitInitProvider.kt
+++ b/cockpit/src/main/java/com/polidea/cockpit/utils/CockpitInitProvider.kt
@@ -8,8 +8,8 @@ import android.net.Uri
 class CockpitInitProvider : ContentProvider() {
 
     override fun onCreate(): Boolean {
-        FileUtils.init(context)
-        FileUtils.getInstance().readCockpitFromFile()
+        FileUtils.init(context.filesDir.path)
+        FileUtils.readCockpitFromFile()
         return false
     }
 

--- a/cockpit/src/main/java/com/polidea/cockpit/utils/FileUtils.kt
+++ b/cockpit/src/main/java/com/polidea/cockpit/utils/FileUtils.kt
@@ -1,6 +1,5 @@
 package com.polidea.cockpit.utils
 
-import android.content.Context
 import com.polidea.cockpit.manager.CockpitManager
 import com.polidea.cockpit.manager.CockpitParam
 import org.yaml.snakeyaml.LoaderOptions
@@ -9,17 +8,21 @@ import java.io.File
 import java.io.FileWriter
 
 
-class FileUtils private constructor(){
-    var cockpitManager = CockpitManager.getInstance()
+object FileUtils {
+    private lateinit var savedCockpitFilePath: String
     private val loaderOptions = LoaderOptions()
-    val yaml: Yaml = Yaml(loaderOptions)
+    private val yaml: Yaml = Yaml(loaderOptions)
+
+    fun init(filesDirPath: String) {
+        savedCockpitFilePath = filesDirPath + File.separator + "savedCockpit.yml"
+    }
 
     fun saveCockpitAsYaml() {
         loaderOptions.isAllowDuplicateKeys = false
-        val fileWriter = FileWriter(SAVED_COCKPIT_FILE_PATH)
+        val fileWriter = FileWriter(savedCockpitFilePath)
 
         val data: LinkedHashMap<String, Any> = LinkedHashMap()
-        cockpitManager.params.forEach {
+        CockpitManager.params.forEach {
             data[it.name] = it.value
         }
 
@@ -27,33 +30,18 @@ class FileUtils private constructor(){
     }
 
     fun readCockpitFromFile() {
-        if (!File(SAVED_COCKPIT_FILE_PATH).exists()) {
+        if (!File(savedCockpitFilePath).exists()) {
             return
         }
 
-        val savedCockpit = File(SAVED_COCKPIT_FILE_PATH)
+        val savedCockpit = File(savedCockpitFilePath)
         val list: Map<String, Any> = yaml.load(savedCockpit.bufferedReader().use {
             it.readText()
         })
 
         list.forEach {
-            cockpitManager.addParam(CockpitParam(it.key, it.value.javaClass, it.value))
+            CockpitManager.addParam(CockpitParam(it.key, it.value.javaClass, it.value))
         }
     }
 
-    companion object {
-        private var SAVED_COCKPIT_FILE_PATH: String? = null
-        private var INSTANCE: FileUtils? = null
-
-        fun init(context: Context) {
-            SAVED_COCKPIT_FILE_PATH = context.filesDir.path + File.separator + "savedCockpit.yml"
-        }
-
-        @JvmStatic
-        fun getInstance(): FileUtils {
-            val instance = INSTANCE ?: FileUtils()
-            INSTANCE = instance
-            return instance
-        }
-    }
 }

--- a/cockpit/src/main/java/com/polidea/cockpit/utils/FileUtils.kt
+++ b/cockpit/src/main/java/com/polidea/cockpit/utils/FileUtils.kt
@@ -9,15 +9,14 @@ import java.io.File
 import java.io.FileWriter
 
 
-class FileUtils(context: Context) {
-    var savedCockpitFilePath = context.filesDir.path + File.separator + "savedCockpit.yml"
+class FileUtils private constructor(){
     var cockpitManager = CockpitManager.getInstance()
     private val loaderOptions = LoaderOptions()
     val yaml: Yaml = Yaml(loaderOptions)
 
     fun saveCockpitAsYaml() {
         loaderOptions.isAllowDuplicateKeys = false
-        val fileWriter = FileWriter(savedCockpitFilePath)
+        val fileWriter = FileWriter(SAVED_COCKPIT_FILE_PATH)
 
         val data: LinkedHashMap<String, Any> = LinkedHashMap()
         cockpitManager.params.forEach {
@@ -28,17 +27,33 @@ class FileUtils(context: Context) {
     }
 
     fun readCockpitFromFile() {
-        if (!File(savedCockpitFilePath).exists()) {
+        if (!File(SAVED_COCKPIT_FILE_PATH).exists()) {
             return
         }
 
-        val savedCockpit = File(savedCockpitFilePath)
+        val savedCockpit = File(SAVED_COCKPIT_FILE_PATH)
         val list: Map<String, Any> = yaml.load(savedCockpit.bufferedReader().use {
             it.readText()
         })
 
         list.forEach {
             cockpitManager.addParam(CockpitParam(it.key, it.value.javaClass, it.value))
+        }
+    }
+
+    companion object {
+        private var SAVED_COCKPIT_FILE_PATH: String? = null
+        private var INSTANCE: FileUtils? = null
+
+        fun init(context: Context) {
+            SAVED_COCKPIT_FILE_PATH = context.filesDir.path + File.separator + "savedCockpit.yml"
+        }
+
+        @JvmStatic
+        fun getInstance(): FileUtils {
+            val instance = INSTANCE ?: FileUtils()
+            INSTANCE = instance
+            return instance
         }
     }
 }

--- a/cockpit/src/main/java/com/polidea/cockpit/utils/ViewUtils.kt
+++ b/cockpit/src/main/java/com/polidea/cockpit/utils/ViewUtils.kt
@@ -4,7 +4,7 @@ import android.view.View
 import android.view.ViewGroup
 import com.polidea.cockpit.view.ParamView
 
-class ViewUtils {
+object ViewUtils {
     fun getFlatChildren(parentView: View): ArrayList<ParamView<*>> {
         val children: ArrayList<ParamView<*>> = ArrayList()
 

--- a/cockpit/src/main/java/com/polidea/cockpit/view/CockpitView.kt
+++ b/cockpit/src/main/java/com/polidea/cockpit/view/CockpitView.kt
@@ -15,7 +15,7 @@ class CockpitView @JvmOverloads constructor(
     }
 
     private fun initialize() {
-        val params = CockpitManager.getInstance().params
+        val params = CockpitManager.params
 
         orientation = VERTICAL
 

--- a/cockpit/src/test/java/com/polidea/cockpit/utils/FileUtilsTest.kt
+++ b/cockpit/src/test/java/com/polidea/cockpit/utils/FileUtilsTest.kt
@@ -1,11 +1,7 @@
 package com.polidea.cockpit.utils
 
-import android.content.Context
 import com.polidea.cockpit.manager.CockpitManager
 import com.polidea.cockpit.manager.CockpitParam
-import io.mockk.classMockk
-import io.mockk.every
-import io.mockk.mockk
 import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -13,25 +9,18 @@ import kotlin.test.assertEquals
 
 class FileUtilsTest {
 
-    private var fileUtils: FileUtils = FileUtils.getInstance()
-
-    private val cockpitManager = CockpitManager.getInstance()
-    private val params = getTestCockpitParams()
-
     init {
-        val contextMock = mockk<Context>(relaxed = true)
         File(DIRECTORY_PATH).mkdirs()
-        every { contextMock.filesDir.path } returns DIRECTORY_PATH
-        FileUtils.init(contextMock)
-        fileUtils.cockpitManager = cockpitManager
-        cockpitManager.params = params
+        FileUtils.init(DIRECTORY_PATH)
     }
 
     @Test
     fun saveAndReadCockpit() {
-        fileUtils.saveCockpitAsYaml()
-        fileUtils.readCockpitFromFile()
-        assertEquals(getTestCockpitParams(), cockpitManager.params)
+        getTestCockpitParams().forEach { CockpitManager.addParam(it) }
+        FileUtils.saveCockpitAsYaml()
+        CockpitManager.clear()
+        FileUtils.readCockpitFromFile()
+        assertEquals(getTestCockpitParams(), CockpitManager.params)
     }
 
     @AfterTest
@@ -47,10 +36,10 @@ class FileUtilsTest {
     private fun getTestCockpitParams(): MutableList<CockpitParam> {
         val testParams: MutableList<CockpitParam> = mutableListOf()
 
-        testParams.add(CockpitParam("doubleParam", Double::class.java, 3.0))
-        testParams.add(CockpitParam("booleanParam", Boolean::class.java, false))
-        testParams.add(CockpitParam("stringParam", String::class.java, "testValue"))
-        testParams.add(CockpitParam("integerParam", Int::class.java, 2))
+        testParams.add(CockpitParam("doubleParam", Double::class.javaObjectType, 3.0))
+        testParams.add(CockpitParam("booleanParam", Boolean::class.javaObjectType, false))
+        testParams.add(CockpitParam("stringParam", String::class.javaObjectType, "testValue"))
+        testParams.add(CockpitParam("integerParam", Int::class.javaObjectType, 2))
 
         return testParams
     }

--- a/cockpit/src/test/java/com/polidea/cockpit/utils/FileUtilsTest.kt
+++ b/cockpit/src/test/java/com/polidea/cockpit/utils/FileUtilsTest.kt
@@ -3,6 +3,8 @@ package com.polidea.cockpit.utils
 import android.content.Context
 import com.polidea.cockpit.manager.CockpitManager
 import com.polidea.cockpit.manager.CockpitParam
+import io.mockk.classMockk
+import io.mockk.every
 import io.mockk.mockk
 import java.io.File
 import kotlin.test.AfterTest
@@ -11,15 +13,17 @@ import kotlin.test.assertEquals
 
 class FileUtilsTest {
 
-    private var context = mockk<Context>(relaxed = true)
-    private var fileUtils: FileUtils = FileUtils(context)
+    private var fileUtils: FileUtils = FileUtils.getInstance()
 
     private val cockpitManager = CockpitManager.getInstance()
     private val params = getTestCockpitParams()
 
     init {
+        val contextMock = mockk<Context>(relaxed = true)
+        File(DIRECTORY_PATH).mkdirs()
+        every { contextMock.filesDir.path } returns DIRECTORY_PATH
+        FileUtils.init(contextMock)
         fileUtils.cockpitManager = cockpitManager
-        fileUtils.savedCockpitFilePath = "test.yml"
         cockpitManager.params = params
     }
 
@@ -31,10 +35,13 @@ class FileUtilsTest {
     }
 
     @AfterTest
-    fun deleteFile() {
-        val f = File(fileUtils.savedCockpitFilePath)
-        val result = f.delete()
-        System.out.println("Deleted file $f: $result")
+    fun deleteFileAndDirectory() {
+        val file = File("$DIRECTORY_PATH/savedCockpit.yml")
+        val fileResult = file.delete()
+        System.out.println("Deleted file $file: $fileResult")
+        val directory = File(DIRECTORY_PATH)
+        val directoryResult = directory.delete()
+        System.out.println("Deleted directory $directory: $directoryResult")
     }
 
     private fun getTestCockpitParams(): MutableList<CockpitParam> {
@@ -46,5 +53,9 @@ class FileUtilsTest {
         testParams.add(CockpitParam("integerParam", Int::class.java, 2))
 
         return testParams
+    }
+
+    companion object {
+        private const val DIRECTORY_PATH = "data"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ GROUP=com.polidea.cockpit
 POM_ARTIFACT_ID=cockpit
 POM_NAME=Cockpit
 POM_PACKAGING=aar
-VERSION_NAME=1.0.1-SNAPSHOT
+VERSION_NAME=1.0.1
 
 POM_DESCRIPTION=Cockpit is an Android library providing a way to easily define a set of parameters that can be accessed and changed by the developers via built-in compact UI at runtime.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ GROUP=com.polidea.cockpit
 POM_ARTIFACT_ID=cockpit
 POM_NAME=Cockpit
 POM_PACKAGING=aar
-VERSION_NAME=1.0.0
+VERSION_NAME=1.0.1-SNAPSHOT
 
 POM_DESCRIPTION=Cockpit is an Android library providing a way to easily define a set of parameters that can be accessed and changed by the developers via built-in compact UI at runtime.
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,12 +7,13 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
 
     dependencies {
-        classpath files('../CockpitPlugin/build/libs/CockpitPlugin-1.0.1.jar')
-        classpath "org.yaml:snakeyaml:1.19"
-        classpath "com.squareup:javapoet:1.10.0"
+        classpath "gradle.plugin.com.polidea.cockpit:CockpitPlugin:1.0.1"
     }
 }
 
@@ -54,10 +55,9 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     testImplementation 'junit:junit:4.12'
+    debugImplementation 'com.polidea.cockpit:cockpit:1.0.1'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
-
-    debugImplementation project(':cockpit')
 }
 
 task wrapper(type: Wrapper) {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath files('../CockpitPlugin/build/libs/CockpitPlugin-1.0.1-SNAPSHOT.jar')
+        classpath files('../CockpitPlugin/build/libs/CockpitPlugin-1.0.1.jar')
         classpath "org.yaml:snakeyaml:1.19"
         classpath "com.squareup:javapoet:1.10.0"
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,13 +7,12 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
     }
 
     dependencies {
-        classpath "gradle.plugin.com.polidea.cockpit:CockpitPlugin:1.0.0"
+        classpath files('../CockpitPlugin/build/libs/CockpitPlugin-1.0.1-SNAPSHOT.jar')
+        classpath "org.yaml:snakeyaml:1.19"
+        classpath "com.squareup:javapoet:1.10.0"
     }
 }
 
@@ -55,9 +54,10 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
     testImplementation 'junit:junit:4.12'
-    debugImplementation 'com.polidea.cockpit:cockpit:1.0.0'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+
+    debugImplementation project(':cockpit')
 }
 
 task wrapper(type: Wrapper) {

--- a/sample/src/main/java/com/polidea/cockpit/sample/MainActivity.kt
+++ b/sample/src/main/java/com/polidea/cockpit/sample/MainActivity.kt
@@ -24,9 +24,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun displayMainActivity() {
-        cockpit_textview.setTextColor(Color.parseColor(Cockpit.getcolor()))
-        cockpit_textview.setTextSize(TypedValue.COMPLEX_UNIT_SP, Cockpit.getfontSize().toFloat())
-        if (Cockpit.getshowFooter()) {
+        cockpit_textview.setTextColor(Color.parseColor(Cockpit.getColor()))
+        cockpit_textview.setTextSize(TypedValue.COMPLEX_UNIT_SP, Cockpit.getFontSize().toFloat())
+        if (Cockpit.getShowFooter()) {
             footer_view.visibility = View.VISIBLE
         } else {
             footer_view.visibility = View.INVISIBLE


### PR DESCRIPTION
Changes for 1.0.1 version:
- getters and setters use camelCase convention
- parameters' changes made by Cockpit.setParam(param) are immediately persisted
- removed Cockpit.hideCockpit(activity: CockpitActivity) method 